### PR TITLE
Update actions/checkout & actions/cache to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}
           path: .cache

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -10,12 +10,12 @@ jobs:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
-       uses: actions/checkout@v2
+       uses: actions/checkout@v4
 
      - uses: actions/setup-python@v4
        with:
           python-version: 3.11
-     - uses: actions/cache@v2
+     - uses: actions/cache@v4
        with:
           key: ${{ github.ref }}
           path: .cache


### PR DESCRIPTION
Starting Feb 1st, actions/cache@v2 and actions/upload-artifact@v3 will be deprecated and workflows using it will result in a failure. Several of our worflows need to be updated to actions/cache@v4 and actions/upload-artifact@v4 respectively by the end of this week.

Ticket: https://accu-knox.atlassian.net/browse/CNAPP-17157