### PR TITLE
DOCS(aws-codepipeline): Remove ACCUKNOX_TENANT and update ASPM scanner to v0.13.4

### DIFF
--- a/docs/integrations/aws-container-scan.md
+++ b/docs/integrations/aws-container-scan.md
@@ -24,7 +24,6 @@ Before beginning the integration, ensure you have the following:
     * 📖 *Reference:* [Add permissions to your CodeBuild service role policy](https://docs.aws.amazon.com/codepipeline/latest/userguide/troubleshooting.html#codebuild-role-connections)
 
 * **AccuKnox API credentials**, including:
-    * Tenant ID
     * Authentication Token
     * Endpoint URL
     * Labels
@@ -46,7 +45,6 @@ Add the following environment variables to your CodeBuild project or pipeline co
 | `ACCUKNOX_ENDPOINT` | The URL of the CSPM panel to push the scan results to.                                                                                | Yes      | `cspm.demo.accuknox.com` |
 | `ACCUKNOX_TOKEN`    | Token for authenticating with the AccuKnox CSPM panel. Refer to [How to Create Tokens](https://help.accuknox.com/how-to/how-to-create-tokens/). | Yes      | `your_api_token_here`    |
 | `ACCUKNOX_LABEL`    | Token for authenticating with the AccuKnox CSPM panel. Refer to [How to Create Tokens](https://help.accuknox.com/how-to/how-to-create-tokens/). | Yes      | `test123`                |
-| `ACCUKNOX_TENANT`   | AccuKnox tenant id.                                                                                                                   | Yes      | `167`                    |
 
 ### Step 2: Configure AWS CodeBuild Specification (buildspec.yml)
 
@@ -66,7 +64,7 @@ phases:
   pre_build:
     commands:
       - echo "Installing AccuKnox ASPM scanner..."
-      - pip install [https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.12.1/accuknox_aspm_scanner-0.12.1-py3-none-any.whl](https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.12.1/accuknox_aspm_scanner-0.12.1-py3-none-any.whl) --break-system-packages
+      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox_aspm_scanner-0.13.4-py3-none-any.whl --break-system-packages
   build:
     commands:
       - |

--- a/docs/integrations/aws-dast.md
+++ b/docs/integrations/aws-dast.md
@@ -24,7 +24,6 @@ Before beginning the integration, ensure you have the following:
     * 📖 *Reference:* [Add permissions to your CodeBuild service role policy](https://docs.aws.amazon.com/codepipeline/latest/userguide/troubleshooting.html#codebuild-role-connections)
 
 * **AccuKnox API credentials** including:
-    * Tenant ID
     * Authentication Token
     * Endpoint URL
     * Labels
@@ -46,7 +45,6 @@ Add the following environment variables to your CodeBuild project or pipeline co
 | `ACCUKNOX_ENDPOINT` | The URL of the CSPM panel to push the scan results to.                                                           | Yes      | `cspm.demo.accuknox.com`   |
 | `ACCUKNOX_TOKEN`    | Token for authenticating with the AccuKnox CSPM panel. Refer to [How to Create Tokens](https://help.accuknox.com/how-to/how-to-create-tokens/). | Yes      | `your_api_token_here`      |
 | `ACCUKNOX_LABEL`    | Labels to associate with the scan results in the AccuKnox platform.                                              | Yes      | `test123`                  |
-| `ACCUKNOX_TENANT`   | AccuKnox tenant ID.                                                                                              | Yes      | `167`                      |
 
 ### Step 2: Configure AWS CodeBuild Specification (buildspec.yml)
 
@@ -65,7 +63,7 @@ phases:
   pre_build:
     commands:
       - echo "Installing AccuKnox ASPM scanner..."
-      - pip install [https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.12.1/accuknox_aspm_scanner-0.12.1-py3-none-any.whl](https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.12.1/accuknox_aspm_scanner-0.12.1-py3-none-any.whl) --break-system-packages
+      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox_aspm_scanner-0.13.4-py3-none-any.whl --break-system-packages
 
   build:
     commands:

--- a/docs/integrations/aws-iac-scan.md
+++ b/docs/integrations/aws-iac-scan.md
@@ -26,7 +26,7 @@ Before beginning the integration, ensure you have the following:
 !!! note "Reference"
     - [Add permissions to your CodeBuild service role policy](https://docs.aws.amazon.com/codepipeline/latest/userguide/troubleshooting.html#codebuild-role-connections)
 
-- **AccuKnox API credentials** including Tenant ID, Authentication Token, Endpoint URL, Labels
+- **AccuKnox API credentials** including Authentication Token, Endpoint URL, Labels
 
 - **Repository Configuration**
   - **Full clone enabled** – Ensure AWS CodePipeline is configured to pass metadata that allows CodeBuild actions to perform a full Git clone.
@@ -47,7 +47,6 @@ Add the following environment variables to your CodeBuild project or pipeline co
 | `ACCUKNOX_ENDPOINT` | The URL of the CSPM panel to push the scan results to.                                                                        | Yes      | `cspm.demo.accuknox.com` |
 | `ACCUKNOX_TOKEN`    | Token for authenticating with the AccuKnox CSPM panel. Refer to [How to Create Tokens](https://help.accuknox.com/how-to/how-to-create-tokens/). | Yes      | `your_api_token_here`    |
 | `ACCUKNOX_LABEL`    | Label used to categorize and organize scan results.                                                                           | Yes      | `test123`                |
-| `ACCUKNOX_TENANT`   | AccuKnox tenant ID.                                                                                                           | Yes      | `167`                    |
 
 ### Step 2: Configure AWS CodeBuild Specification (`buildspec.yml`)
 
@@ -67,7 +66,7 @@ phases:
   pre_build:
     commands:
       - echo "Installing AccuKnox ASPM scanner..."
-      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.12.1/accuknox_aspm_scanner-0.12.1-py3-none-any.whl --break-system-packages
+      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox_aspm_scanner-0.13.4-py3-none-any.whl --break-system-packages
 
   build:
     commands: |

--- a/docs/integrations/aws-sast.md
+++ b/docs/integrations/aws-sast.md
@@ -25,7 +25,6 @@ Before beginning the integration, ensure you have the following:
     * 📖 *Reference:* [Add permissions to your CodeBuild service role policy](https://docs.aws.amazon.com/codepipeline/latest/userguide/troubleshooting.html#codebuild-role-connections)
 
 * **AccuKnox SAST API credentials**, including:
-    * Tenant ID
     * Authentication Token
     * Endpoint URL
     * Labels
@@ -47,7 +46,6 @@ Add the following environment variables to your CodeBuild project or pipeline co
 | `ACCUKNOX_ENDPOINT` | The URL of the CSPM panel to push the scan results to.                                                                                | Yes      | `cspm.demo.accuknox.com` |
 | `ACCUKNOX_TOKEN`    | Token for authenticating with the AccuKnox CSPM panel. Refer to [How to Create Tokens](https://help.accuknox.com/how-to/how-to-create-tokens/). | Yes      | `your_api_token_here`    |
 | `ACCUKNOX_LABEL`    | The label used to categorize and identify scan results in AccuKnox. Refer to [How to Create Labels](https://help.accuknox.com/how-to/how-to-create-labels/). | Yes      | `test123`                |
-| `ACCUKNOX_TENANT`   | AccuKnox tenant id.                                                                                                                   | Yes      | `167`                    |
 
 ### Step 2: Configure AWS CodeBuild Specification (buildspec.yml)
 
@@ -64,7 +62,7 @@ phases:
   pre_build:
     commands:
       - echo "Installing AccuKnox ASPM scanner..."
-      - pip install [https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.12.1/accuknox_aspm_scanner-0.12.1-py3-none-any.whl](https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.12.1/accuknox_aspm_scanner-0.12.1-py3-none-any.whl) --break-system-packages
+      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox_aspm_scanner-0.13.4-py3-none-any.whl --break-system-packages
 
   build:
     commands:

--- a/docs/integrations/aws-secret-scan.md
+++ b/docs/integrations/aws-secret-scan.md
@@ -25,7 +25,6 @@ Before beginning the integration, ensure you have the following:
   📖 *Reference:* [Add permissions to your CodeBuild service role policy](https://docs.aws.amazon.com/codepipeline/latest/userguide/troubleshooting.html#codebuild-role-connections)
 
 - **AccuKnox API credentials**, including:
-    - Tenant ID
     - Authentication Token
     - Endpoint URL
     - Labels
@@ -47,7 +46,6 @@ Add the following environment variables to your CodeBuild project or pipeline co
 | `ACCUKNOX_ENDPOINT` | The URL of the CSPM panel to push the scan results to                                                      | Yes          | `cspm.demo.accuknox.com`    |
 | `ACCUKNOX_TOKEN`    | Token for authenticating with the AccuKnox CSPM panel. [How to Create Tokens](https://help.accuknox.com/how-to/how-to-create-tokens/) | Yes          | `your_api_token_here`       |
 | `ACCUKNOX_LABEL`    | Label identifier for organizing scan results                                                               | Yes          | `test123`                   |
-| `ACCUKNOX_TENANT`   | AccuKnox tenant ID                                                                                        | Yes          | `167`                       |
 
 
 ### Step 2: Configure AWS CodeBuild Specification (`buildspec.yml`)
@@ -67,7 +65,7 @@ phases:
   pre_build:
     commands:
       - echo "Installing AccuKnox ASPM scanner..."
-      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.12.1/accuknox_aspm_scanner-0.12.1-py3-none-any.whl --break-system-packages
+      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox_aspm_scanner-0.13.4-py3-none-any.whl --break-system-packages
 
   build:
     commands:


### PR DESCRIPTION
## Summary
This PR updates AWS CodePipeline integration documentation by removing deprecated `ACCUKNOX_TENANT` references and updating the ASPM scanner to the latest version.

## Changes Made
- **Removed ACCUKNOX_TENANT**: Eliminated tenant ID references from prerequisites and environment variables across all AWS integration docs
- **Updated ASPM Scanner**: Bumped pip install command from v0.12.1 to v0.13.4 across all AWS integrations
- **Cleaned up prerequisites**: Removed "Tenant ID" from API credentials sections

## Files Modified
- `integrations/aws-container-scan.md`
- `integrations/aws-dast.md` 
- `integrations/aws-iac-scan.md`
- `integrations/aws-sast.md`
- `integrations/aws-secret-scan.md`