### PR TITLE
Update AWS CodePipeline buildspecs and CircleCI orb version.

### DIFF
--- a/docs/integrations/aws-dast.md
+++ b/docs/integrations/aws-dast.md
@@ -58,14 +58,17 @@ version: 0.2
 env:
   variables:
     SOFT_FAIL: "true"
-    TARGET_URL: "[https://juice-shop.herokuapp.com/](https://juice-shop.herokuapp.com/)"
+    TARGET_URL: "https://juice-shop.herokuapp.com/"
     DAST_SCAN_SCRIPT: "zap-baseline.py"
 
 phases:
+  install:
+    runtime-versions:
+      python: 3.11
   pre_build:
     commands:
       - echo "Installing AccuKnox ASPM scanner..."
-      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox_aspm_scanner-0.13.4-py3-none-any.whl --break-system-packages
+      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.2/accuknox_aspm_scanner-0.14.2-py3-none-any.whl --break-system-packages
 
   build:
     commands:

--- a/docs/integrations/aws-iac-scan.md
+++ b/docs/integrations/aws-iac-scan.md
@@ -63,10 +63,13 @@ env:
     QUIET: "true"
 
 phases:
+  install:
+    runtime-versions:
+      python: 3.11
   pre_build:
     commands:
       - echo "Installing AccuKnox ASPM scanner..."
-      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox_aspm_scanner-0.13.4-py3-none-any.whl --break-system-packages
+      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.2/accuknox_aspm_scanner-0.14.2-py3-none-any.whl --break-system-packages
 
   build:
     commands: |

--- a/docs/integrations/aws-sast.md
+++ b/docs/integrations/aws-sast.md
@@ -59,10 +59,13 @@ env:
     SOFT_FAIL: "true"
 
 phases:
+  install:
+    runtime-versions:
+      python: 3.11
   pre_build:
     commands:
       - echo "Installing AccuKnox ASPM scanner..."
-      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox_aspm_scanner-0.13.4-py3-none-any.whl --break-system-packages
+      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.2/accuknox_aspm_scanner-0.14.2-py3-none-any.whl --break-system-packages
 
   build:
     commands:

--- a/docs/integrations/aws-secret-scan.md
+++ b/docs/integrations/aws-secret-scan.md
@@ -62,10 +62,13 @@ env:
     EXCLUDE_PATHS: ""
 
 phases:
+  install:
+    runtime-versions:
+      python: 3.11
   pre_build:
     commands:
       - echo "Installing AccuKnox ASPM scanner..."
-      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox_aspm_scanner-0.13.4-py3-none-any.whl --break-system-packages
+      - pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.2/accuknox_aspm_scanner-0.14.2-py3-none-any.whl --break-system-packages
 
   build:
     commands:

--- a/docs/integrations/circleci-container-scan.md
+++ b/docs/integrations/circleci-container-scan.md
@@ -70,7 +70,7 @@ Update your CircleCI configuration file (`.circleci/config.yml`) to include the 
 version: 2.1
 
 orbs:
-  accuknox-scan: accuknox/scan@1.0.4
+  accuknox-scan: accuknox/scan@1.0.5
 
 jobs:
   build-docker-image:

--- a/docs/integrations/circleci-dast.md
+++ b/docs/integrations/circleci-dast.md
@@ -66,7 +66,7 @@ To integrate DAST scanning, modify your `.circleci/config.yml` file using the Ac
 version: 2.1
 
 orbs:
-  accuknox-scan: accuknox/scan@1.0.4
+  accuknox-scan: accuknox/scan@1.0.5
 
 workflows:
   accuknox:

--- a/docs/integrations/circleci-iac-scan.md
+++ b/docs/integrations/circleci-iac-scan.md
@@ -60,7 +60,7 @@ Update your `.circleci/config.yml` with the `iac` job from the AccuKnox plugin.
 version: 2.1
 
 orbs:
-  accuknox-scan: accuknox/scan@1.0.4
+  accuknox-scan: accuknox/scan@1.0.5
 
 workflows:
   accuknox:

--- a/docs/integrations/circleci-sast.md
+++ b/docs/integrations/circleci-sast.md
@@ -59,7 +59,7 @@ Update your `.circleci/config.yml` file to include the AccuKnox SAST scan:
 version: 2.1
 
 orbs:
-  accuknox-scan: accuknox/scan@1.0.4
+  accuknox-scan: accuknox/scan@1.0.5
 
 workflows:
   accuknox:

--- a/docs/integrations/circleci-secret-scan.md
+++ b/docs/integrations/circleci-secret-scan.md
@@ -68,7 +68,7 @@ Update your CircleCI configuration file (`.circleci/config.yml`) to include the 
 version: 2.1
 
 orbs:
-  accuknox-scan: accuknox/scan@1.0.4
+  accuknox-scan: accuknox/scan@1.0.5
 
 workflows:
   accuknox:

--- a/docs/integrations/circleci-sqsast.md
+++ b/docs/integrations/circleci-sqsast.md
@@ -80,7 +80,7 @@ Add the `sq-sast` job to your `.circleci/config.yml` file and attach the context
 version: 2.1
 
 orbs:
-  accuknox-scan: accuknox/scan@1.0.4
+  accuknox-scan: accuknox/scan@1.0.5
 
 workflows:
   accuknox:


### PR DESCRIPTION
Refresh AWS scan examples to ASPM scanner v0.14.2 and bump the CircleCI scan orb to 1.0.5.