### PR TITLE
Document OpenShift REDHAT_CERTIFIED_OP onboarding flags and add FAQ e…

### DIFF
--- a/docs/faqs/runtime-security.md
+++ b/docs/faqs/runtime-security.md
@@ -65,6 +65,18 @@ hide:
 
     This helps confirm whether KubeArmor or other critical services are active inside the VM for proper enforcement and telemetry.
 
+??? "**9. Onboarding an OpenShift cluster fails with the KubeArmor Operator pod not coming up. What should I check?**"
+    This usually happens when OpenShift's Security Context Constraints (SCC) block the KubeArmor Operator because it isn't identified as a Red Hat certified operator. Symptoms include the operator pod stuck in `CrashLoopBackOff`/`Error` state, or errors such as `unable to validate against any security context constraint`.
+
+    To fix this, add the following flags to the [onboarding helm command](../how-to/cluster-onboarding.md) for OpenShift clusters:
+
+    ```sh
+    --set kubearmor-operator.kubearmorOperator.env[0].name=REDHAT_CERTIFIED_OP \
+    --set kubearmor-operator.kubearmorOperator.env[0].value=true \
+    ```
+
+    These flags mark the operator as Red Hat certified so it satisfies OpenShift's SCC requirements and deploys successfully.
+
 ---
 
 [SCHEDULE DEMO](https://www.accuknox.com/contact-us){ .md-button .md-button--primary }

--- a/docs/getting-started/security-on-openshift.md
+++ b/docs/getting-started/security-on-openshift.md
@@ -5,6 +5,9 @@ description: Guide to deploying KubeArmor runtime security enforcement on OpenSh
 
 # Runtime Security Deployment for Openshift
 
+!!! info "Onboarding via the AccuKnox Helm Command"
+    If you're onboarding this OpenShift cluster using the [AccuKnox agents helm command](../how-to/cluster-onboarding.md) instead of the OperatorHub console flow below, add the `REDHAT_CERTIFIED_OP` flags described in that guide so the KubeArmor Operator satisfies OpenShift's Security Context Constraints (SCC).
+
 ## Operator Installation
 
 In the OpenShift console, install KubeArmor operator by following the instructions below:

--- a/docs/how-to/cluster-onboarding.md
+++ b/docs/how-to/cluster-onboarding.md
@@ -73,6 +73,14 @@ helm upgrade --install agents oci://public.ecr.aws/k9v9d5v2/kspm-runtime \
     ```
     In the above command joinToken is specific to this example and it will vary based on the cluster being onboarded.
 
+!!! info "OpenShift Clusters"
+    If you are onboarding an **OpenShift** cluster, add the following flags to the helm command so that the KubeArmor Operator is recognized as a Red Hat certified operator:
+    ```sh
+    --set kubearmor-operator.kubearmorOperator.env[0].name=REDHAT_CERTIFIED_OP \
+    --set kubearmor-operator.kubearmorOperator.env[0].value=true \
+    ```
+    Without these flags, OpenShift's Security Context Constraints (SCC) can block the KubeArmor Operator pod from coming up, since it isn't identified as a Red Hat certified operator. This can surface as errors like `unable to validate against any security context constraint`, or the operator pod getting stuck in `CrashLoopBackOff`/`Error` state. See the [Runtime Security FAQ](../faqs/runtime-security.md) for troubleshooting.
+
 ## View Onboarded Clusters
 
 **Step 4:** Onboarded Cluster

--- a/docs/integrations/claude-browser-integration.md
+++ b/docs/integrations/claude-browser-integration.md
@@ -43,7 +43,7 @@ After saving, the token is displayed once in a confirmation modal.
 
 ## Step 3: Download and install the browser plugin
 
-[Download Chrome plugin](https://promptfirewall-plugin-extension.s3.ap-south-1.amazonaws.com/Prompt-firewall-plugin-v4.zip) and extract the ZIP file to a folder on your machine.
+[Download Chrome plugin](https://drive.google.com/file/d/1Sn4LoZDT-q8vyF9vMsNkL7WvQpb9GHg7/view?usp=sharing), download the ZIP file from Google Drive, and extract it to a folder on your machine.
 
 To install in Chrome:
 

--- a/docs/integrations/openai-browser-integration.md
+++ b/docs/integrations/openai-browser-integration.md
@@ -41,7 +41,7 @@ After saving, the token is displayed once in a confirmation modal.
 
 ## Step 3: Download and install the browser plugin
 
-[Download Chrome plugin](https://promptfirewall-plugin-extension.s3.ap-south-1.amazonaws.com/Prompt-firewall-plugin-v4.zip) and extract the ZIP file to a folder on your machine.
+[Download Chrome plugin](https://drive.google.com/file/d/1Sn4LoZDT-q8vyF9vMsNkL7WvQpb9GHg7/view?usp=sharing), download the ZIP file from Google Drive, and extract it to a folder on your machine.
 
 To install in Chrome:
 

--- a/docs/integrations/openai-firefox-browser-integration.md
+++ b/docs/integrations/openai-firefox-browser-integration.md
@@ -41,7 +41,7 @@ After saving, the token is displayed once in a confirmation modal.
 
 ## Step 3: Download and install the browser plugin
 
-[Download Firefox plugin](https://promptfirewall-plugin-extension.s3.ap-south-1.amazonaws.com/Prompt-firewall-plugin-v4.zip) and extract the ZIP file to a folder on your machine.
+[Download Firefox plugin](https://drive.google.com/file/d/1Sn4LoZDT-q8vyF9vMsNkL7WvQpb9GHg7/view?usp=sharing), download the ZIP file from Google Drive, and extract it to a folder on your machine.
 
 To install in Firefox:
 


### PR DESCRIPTION
…ntry

Onboarding an OpenShift cluster via the AccuKnox helm command needs extra kubearmor-operator env flags so the operator satisfies OpenShift's SCC requirements. Documented in cluster-onboarding.md, cross-linked from security-on-openshift.md, and added a runtime-security FAQ entry for the resulting error.