### PR TITLE
Restructure GenAI Browser Plugin docs by browser, not by app

### DIFF
--- a/docs/faqs/ai-security.md
+++ b/docs/faqs/ai-security.md
@@ -278,7 +278,7 @@ hide:
     The prompt firewall operates as an inline proxy — intercepting and inspecting every interaction between the application and the LLM provider before it completes.
 
     **References:**
-    - [GenAI Browser Integration](https://help.accuknox.com/integrations/openai-browser-integration/)
+    - [GenAI Browser Integration](https://help.accuknox.com/integrations/chrome-browser-integration/)
     - [Amazon Bedrock AgentCore Integration](https://help.accuknox.com/integrations/bedrock-agentcore/)
     - [Power Apps Integration](https://help.accuknox.com/integrations/powerapps-integration/)
 

--- a/docs/getting-started/3.5-release.md
+++ b/docs/getting-started/3.5-release.md
@@ -112,8 +112,9 @@ Every intercepted prompt and response is logged under **AI Security > Request Lo
 
 **Installation guides:**
 
-- [Chrome, Brave, and Edge →](/integrations/openai-browser-integration/)
-- [Firefox →](/integrations/openai-firefox-browser-integration/)
+- [Chrome →](/integrations/chrome-browser-integration/)
+- [Edge →](/integrations/edge-browser-integration/)
+- [Firefox →](/integrations/firefox-browser-integration/)
 
 !!! note "Firefox and Safari installation"
     Firefox loads the extension as a temporary add-on via `about:debugging`. Safari requires Developer Mode enabled and loads the extension as an unsigned package. Both unload when the browser restarts. Contact AccuKnox support if you need a permanent deployment option.

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -58,6 +58,7 @@ Integration guides for CI/CD, SIEM, ticketing, registries, SSO, AI gateways, K8s
 | [bitbucket-sast.md](bitbucket-sast.md) | Integrate SonarQube SAST into Bitbucket CI/CD with AccuKnox to detect and fix code vulnerabilities before deployment. |
 | [bitbucket-secret-scan.md](bitbucket-secret-scan.md) | This guide explains integrating AccuKnox Secret Scanning into your Bitbucket CI/CD Pipeline. The integration enhances code security by detecting hard-coded s... |
 | [checkmarx.md](checkmarx.md) | Use Checkmarx SAST with AccuKnox to detect code flaws in CI/CD pipelines and enrich results with metadata for analysis. |
+| [chrome-browser-integration.md](chrome-browser-integration.md) | A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Chrome and real-time prompt and response filtering in ChatGPT, Claude, Gi... |
 | [cicd-overview.md](cicd-overview.md) | Check out the integration mechanisms and feature availability for key DevOps and security functionalities across popular CI/CD platforms. |
 | [circleci-container-scan.md](circleci-container-scan.md) | Detect vulnerabilities in Docker images directly within your CircleCI CI/CD pipeline using the AccuKnox container scanning plugin. |
 | [circleci-dast.md](circleci-dast.md) | Integrate Dynamic Application Security Testing (DAST) into your CircleCI pipeline using the AccuKnox plugin to identify application-layer vulnerabilities bef... |
@@ -66,12 +67,13 @@ Integration guides for CI/CD, SIEM, ticketing, registries, SSO, AI gateways, K8s
 | [circleci-sast.md](circleci-sast.md) | Integrate Static Application Security Testing (SAST) scans into your CircleCI pipeline using the AccuKnox plugin to identify vulnerabilities in source code e... |
 | [circleci-secret-scan.md](circleci-secret-scan.md) | Detect hardcoded secrets and sensitive credentials in your codebase using AccuKnox Secret Scanning integrated into CircleCI pipelines. |
 | [circleci-sqsast.md](circleci-sqsast.md) | Integrate SonarQube-based SAST into CircleCI with AccuKnox for centralized vulnerability visibility, analysis, and triage. |
-| [claude-browser-integration.md](claude-browser-integration.md) | A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Chrome, Chromium-based browsers, and real-time prompt and response filter... |
 | [connectwise-cspm.md](connectwise-cspm.md) | Automate security alerts in Connectwise by integrating AccuKnox to generate tickets and enhance security workflows. |
 | [copilot-studio.md](copilot-studio.md) | Steps to integrate AccuKnox with Copilot Studio (CP Studio) for enhanced AI-driven security management. |
+| [edge-browser-integration.md](edge-browser-integration.md) | A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Microsoft Edge and real-time prompt and response filtering in ChatGPT, Cl... |
 | [email-backend.md](email-backend.md) | The Email Backend Integration allows making use of your own SMTP server to send all Emails that originate from the AccuKnox platform. |
 | [email.md](email.md) | This document explains how to integrate Email with AccuKnox to receive alert notifications via mail. |
 | [f5.md](f5.md) | Integrate F5 Big-IP with AccuKnox API Security for API traffic monitoring, observability, and security enforcement. |
+| [firefox-browser-integration.md](firefox-browser-integration.md) | A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Firefox and real-time prompt and response filtering in ChatGPT, Claude, G... |
 | [freshservice-cspm.md](freshservice-cspm.md) | Automate security alerts in Freshservice by integrating AccuKnox to create problem alerts and improve workflow response. |
 | [github-actions-secret-scan.md](github-actions-secret-scan.md) | Integrate AccuKnox Secret Scanning into your GitHub Actions CI/CD workflow to detect hardcoded secrets and sensitive credentials before they reach production. |
 | [github-container-scan.md](github-container-scan.md) | Learn how to integrate container scanning with AccuKnox in a GitHub CI/CD pipeline to identify and remediate vulnerabilities in Docker images. |
@@ -126,8 +128,6 @@ Integration guides for CI/CD, SIEM, ticketing, registries, SSO, AI gateways, K8s
 | [nutanix-accuknox.md](nutanix-accuknox.md) | Install AccuKnox agents on a D2iQ managed cluster and onboard to AccuKnox SaaS to get visibility into your Kubernetes clusters. |
 | [nutanix-kubearmor.md](nutanix-kubearmor.md) | Integrate KubeArmor with Nutanix to enforce security policies at the pod and node level for your Nutanix clusters. |
 | [okta-sso.md](okta-sso.md) | Integrate Okta with AccuKnox using OpenID Connect (OIDC) for Single Sign-On (SSO) authentication. |
-| [openai-browser-integration.md](openai-browser-integration.md) | A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Chrome, Chromium-based browsers, and real-time prompt and response filter... |
-| [openai-firefox-browser-integration.md](openai-firefox-browser-integration.md) | A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Firefox and real-time prompt and response filtering in ChatGPT. |
 | [opengrep-sast-bitbucket.md](opengrep-sast-bitbucket.md) | Integrate Opengrep SAST scanning into Bitbucket Pipelines and automatically forward results to AccuKnox for analysis and mitigation. |
 | [opengrep-sast.md](opengrep-sast.md) | Integrate Opengrep SAST scanning into a GitHub Actions workflow and forward results to AccuKnox for security analysis and mitigation. |
 | [oracle-playbook.md](oracle-playbook.md) | Step-by-step guide to subscribing and managing AccuKnox via Oracle Marketplace for streamlined deployment and monitoring. |

--- a/docs/integrations/ai-overview.md
+++ b/docs/integrations/ai-overview.md
@@ -68,7 +68,7 @@ Inline prompt and response protection through the SDK, AI gateways, and app plat
 ::/cards::
 
 !!! tip "Browser-based Guardrails"
-    For prompt protection directly in the browser, see the GenAI Browser Plugins for [Chrome (ChatGPT)](../integrations/openai-browser-integration.md), [Chrome (Claude)](../integrations/claude-browser-integration.md), and [Firefox](../integrations/openai-firefox-browser-integration.md).
+    For prompt protection directly in the browser, see the GenAI Browser Plugins for [Chrome](../integrations/chrome-browser-integration.md), [Edge](../integrations/edge-browser-integration.md), and [Firefox](../integrations/firefox-browser-integration.md).
 
 ## Agentic AI Security
 

--- a/docs/integrations/chrome-browser-integration.md
+++ b/docs/integrations/chrome-browser-integration.md
@@ -1,19 +1,21 @@
 ---
 title: Prompt Firewall Gen AI Browser Integration (Chrome)
-description: A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Chrome, Chromium-based browsers, and real-time prompt and response filtering in ChatGPT.
+description: A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Chrome and real-time prompt and response filtering in ChatGPT, Claude, GitHub Copilot, and Gemini.
 ---
 
 # Gen AI Browser Integration for Prompt Security (Chrome)
 
-The AccuKnox Prompt Firewall browser plugin intercepts prompts and responses directly in ChatGPT before they leave your browser session. Blocked prompts show a red banner. Allowed ones pass through silently.
+The AccuKnox Prompt Firewall browser plugin intercepts prompts and responses directly in ChatGPT, Claude, GitHub Copilot, and Gemini before they leave your browser session. This includes blocking prompt injection attacks, where a malicious input tries to override the model's behavior. Blocked prompts show a red banner. Allowed ones pass through silently.
 
-This guide covers installation for **Chrome, Brave, and Edge** (Chromium-based browsers). For Firefox, see the [Firefox integration guide](openai-firefox-browser-integration.md).
+![Red banner - Prompt blocked](prompt-block-1.png)
+
+The same plugin covers all four apps at once, no separate install needed per app. This guide covers installation for **Chrome**. For Edge, see the [Edge integration guide](edge-browser-integration.md). For Firefox, see the [Firefox integration guide](firefox-browser-integration.md).
 
 ## Prerequisites
 
 - An active AccuKnox account with AI Security enabled
 - Access to the Integrations section (to generate a token)
-- A Chromium-based browser (Chrome, Brave, or Edge)
+- Google Chrome browser
 
 ## Step 1: Create a new integration
 
@@ -25,7 +27,7 @@ Fill in the following fields:
 
 | Field | Value |
 |---|---|
-| Integration Name | Any descriptive name (e.g. `openai-browser-prod`) |
+| Integration Name | Any descriptive name (e.g. `chrome-browser-prod`) |
 | Tags | Add relevant tags (e.g. `llmguard`) |
 
 Click **Add** to save.
@@ -41,7 +43,7 @@ After saving, the token is displayed once in a confirmation modal.
 
 ## Step 3: Download and install the browser plugin
 
-[Download Chrome plugin](https://drive.google.com/file/d/1Sn4LoZDT-q8vyF9vMsNkL7WvQpb9GHg7/view?usp=sharing), download the ZIP file from Google Drive, and extract it to a folder on your machine.
+[Download the plugin](https://drive.google.com/file/d/1Sn4LoZDT-q8vyF9vMsNkL7WvQpb9GHg7/view?usp=sharing), download the ZIP file from Google Drive, and extract it to a folder on your machine.
 
 To install in Chrome:
 
@@ -55,7 +57,7 @@ To install in Chrome:
 
 Click the AccuKnox icon in your browser toolbar and open **Settings**.
 
-Fill in the two fields:
+Fill in the following field:
 
 | Field | Value |
 |---|---|
@@ -69,14 +71,12 @@ Click **Save Settings**, then **Test Connection**.
 
 Once connected, the extension popup shows a green status dot next to **AccuKnox Prompt Firewall** along with a running count of scanned, allowed, blocked, and warned prompts. Click **View Logs** to see the full request log.
 
-Open ChatGPT and send a test prompt. Depending on your active policy, you will see one of the following:
-
+Open ChatGPT, Claude, GitHub Copilot, or Gemini and send a test prompt. Depending on your active policy, you will see one of the following:
 
 ![Red banner - Prompt blocked](image-63.png)
 ![Green banner - Prompt cleared](image-64.png)
 
 ## Request log
-
 
 All intercepted prompts and responses are visible under **AI Security > Request Log**.
 

--- a/docs/integrations/edge-browser-integration.md
+++ b/docs/integrations/edge-browser-integration.md
@@ -1,21 +1,21 @@
 ---
-title: Prompt Firewall Gen AI Browser Integration (Claude)
-description: A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Chrome, Chromium-based browsers, and real-time prompt and response filtering in Claude.
+title: Prompt Firewall Gen AI Browser Integration (Edge)
+description: A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Microsoft Edge and real-time prompt and response filtering in ChatGPT, Claude, GitHub Copilot, and Gemini.
 ---
 
-# Gen AI Browser Integration for Prompt Security (Claude)
+# Gen AI Browser Integration for Prompt Security (Edge)
 
-The AccuKnox Prompt Firewall browser plugin intercepts prompts and responses directly in Claude before they leave your browser session. This includes blocking prompt injection attacks, where a malicious input tries to override Claude's behavior. Blocked prompts show a red banner. Allowed ones pass through silently.
+The AccuKnox Prompt Firewall browser plugin intercepts prompts and responses directly in ChatGPT, Claude, GitHub Copilot, and Gemini before they leave your browser session. This includes blocking prompt injection attacks, where a malicious input tries to override the model's behavior. Blocked prompts show a red banner. Allowed ones pass through silently.
 
 ![Red banner - Prompt blocked](prompt-block-1.png)
 
-This guide covers installation for **Chrome, Brave, and Edge** (Chromium-based browsers). The same plugin works for both Claude and ChatGPT — no separate install needed.
+The same plugin covers all four apps at once, no separate install needed per app. This guide covers installation for **Microsoft Edge**. For Chrome, see the [Chrome integration guide](chrome-browser-integration.md). For Firefox, see the [Firefox integration guide](firefox-browser-integration.md).
 
 ## Prerequisites
 
 - An active AccuKnox account with AI Security enabled
 - Access to the Integrations section (to generate a token)
-- A Chromium-based browser (Chrome, Brave, or Edge)
+- Microsoft Edge browser
 
 ## Step 1: Create a new integration
 
@@ -27,7 +27,7 @@ Fill in the following fields:
 
 | Field | Value |
 |---|---|
-| Integration Name | Any descriptive name (e.g. `claude-browser-prod`) |
+| Integration Name | Any descriptive name (e.g. `edge-browser-prod`) |
 | Tags | Add relevant tags (e.g. `llmguard`) |
 
 Click **Add** to save.
@@ -43,12 +43,12 @@ After saving, the token is displayed once in a confirmation modal.
 
 ## Step 3: Download and install the browser plugin
 
-[Download Chrome plugin](https://drive.google.com/file/d/1Sn4LoZDT-q8vyF9vMsNkL7WvQpb9GHg7/view?usp=sharing), download the ZIP file from Google Drive, and extract it to a folder on your machine.
+[Download the plugin](https://drive.google.com/file/d/1Sn4LoZDT-q8vyF9vMsNkL7WvQpb9GHg7/view?usp=sharing), download the ZIP file from Google Drive, and extract it to a folder on your machine.
 
-To install in Chrome:
+To install in Edge:
 
-1. Go to `chrome://extensions`
-2. Enable **Developer mode** (top-right toggle)
+1. Go to `edge://extensions`
+2. Enable **Developer mode** (toggle in the left sidebar)
 3. Click **Load unpacked** and select the extracted plugin folder
 
 ## Step 4: Configure the extension
@@ -57,7 +57,7 @@ To install in Chrome:
 
 Click the AccuKnox icon in your browser toolbar and open **Settings**.
 
-Fill in the two fields:
+Fill in the following field:
 
 | Field | Value |
 |---|---|
@@ -71,9 +71,10 @@ Click **Save Settings**, then **Test Connection**.
 
 Once connected, the extension popup shows a green status dot next to **AccuKnox Prompt Firewall** along with a running count of scanned, allowed, blocked, and warned prompts. Click **View Logs** to see the full request log.
 
-Open Claude and send a test prompt. Depending on your active policy, you will see one of the following:
+Open ChatGPT, Claude, GitHub Copilot, or Gemini and send a test prompt. Depending on your active policy, you will see one of the following:
 
-
+![Red banner - Prompt blocked](image-63.png)
+![Green banner - Prompt cleared](image-64.png)
 
 ## Request log
 

--- a/docs/integrations/firefox-browser-integration.md
+++ b/docs/integrations/firefox-browser-integration.md
@@ -1,13 +1,13 @@
 ---
 title: Prompt Firewall Gen AI Browser Integration (Firefox)
-description: A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Firefox and real-time prompt and response filtering in ChatGPT.
+description: A step-by-step guide to configuring the AccuKnox Prompt Firewall browser plugin for Firefox and real-time prompt and response filtering in ChatGPT, Claude, GitHub Copilot, and Gemini.
 ---
 
 # Gen AI Browser Integration for Prompt Security (Firefox)
 
-The AccuKnox Prompt Firewall browser plugin intercepts prompts and responses directly in ChatGPT before they leave your browser session. Blocked prompts show a red banner. Allowed ones pass through silently.
+The AccuKnox Prompt Firewall browser plugin intercepts prompts and responses directly in ChatGPT, Claude, GitHub Copilot, and Gemini before they leave your browser session. This includes blocking prompt injection attacks, where a malicious input tries to override the model's behavior. Blocked prompts show a red banner. Allowed ones pass through silently.
 
-This guide covers installation for **Mozilla Firefox**. For Chromium-based browsers (Chrome, Brave, Edge), see the [Chrome integration guide](openai-browser-integration.md).
+The same plugin covers all four apps at once, no separate install needed per app. This guide covers installation for **Mozilla Firefox**. For Chrome, see the [Chrome integration guide](chrome-browser-integration.md). For Edge, see the [Edge integration guide](edge-browser-integration.md).
 
 ## Prerequisites
 
@@ -78,7 +78,7 @@ Click **Save Settings**, then **Test Connection**.
 
 Once connected, the extension popup shows a green status dot next to **AccuKnox Prompt Firewall** along with a running count of scanned, allowed, blocked, and warned prompts. Click **View Logs** to see the full request log.
 
-Open ChatGPT and send a test prompt. Depending on your active policy, you will see one of the following:
+Open ChatGPT, Claude, GitHub Copilot, or Gemini and send a test prompt. Depending on your active policy, you will see one of the following:
 
 ![Red banner - Prompt blocked](image-63.png)
 ![Green banner - Prompt cleared](image-64.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,9 @@ plugins:
         'use-cases/bitbucket-secret-scan.md': 'integrations/bitbucket-secret-scan.md'
         'use-cases/jenkins-secret-scan.md': 'integrations/jenkins-secret-scan.md'
         'use-cases/github-secret-scan.md': 'integrations/github-actions-secret-scan.md'
+        'integrations/openai-browser-integration.md': 'integrations/chrome-browser-integration.md'
+        'integrations/claude-browser-integration.md': 'integrations/chrome-browser-integration.md'
+        'integrations/openai-firefox-browser-integration.md': 'integrations/firefox-browser-integration.md'
   - search:
       separator: '[\s\-\.]+'
       lang:
@@ -326,9 +329,9 @@ nav:
         - "SDK Method": "how-to/llm-defense-app-onboard.md"
         - "Apigee Proxy": "integrations/apigee-integration.md"
         - "GenAI Browser Plugin":
-          - "Chrome (ChatGPT)": "integrations/openai-browser-integration.md"
-          - "Chrome (Claude)": "integrations/claude-browser-integration.md"
-          - "Firefox": "integrations/openai-firefox-browser-integration.md"
+          - "Chrome": "integrations/chrome-browser-integration.md"
+          - "Edge": "integrations/edge-browser-integration.md"
+          - "Firefox": "integrations/firefox-browser-integration.md"
       - "Azure Copilot Studio": "integrations/copilot-studio.md"
       - "BedRock AgentCore": "integrations/bedrock-agentcore.md"
       - "Power Apps": "integrations/powerapps-integration.md"


### PR DESCRIPTION
The plugin already covers ChatGPT, Claude, GitHub Copilot, and Gemini in a single install regardless of browser, so per-app pages (Chrome ChatGPT, Chrome Claude) were redundant. Split into per-browser guides instead: Chrome, Edge, and Firefox, each app-agnostic. Adds redirects for the old URLs and fixes cross-links across the site.