### PR TITLE
Update Jenkins ASPM plugin download URL

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -20,6 +20,7 @@ Getting-started material: installation, on-prem deployment, architecture, and re
 | [3.3-release.md](3.3-release.md) | Discover the latest features, enhancements, and fixes in AccuKnox v3.3, focusing on improved operational efficiency and expanded platform coverage. |
 | [3.4-release.md](3.4-release.md) | Discover the latest features, enhancements, and integrations in AccuKnox v3.4, including SCA, Dashboard V3, AI-powered automation, expanded cloud governance,... |
 | [3.5-release.md](3.5-release.md) | AccuKnox v3.5 adds GitHub Actions pipeline auditing, an AI Widget Builder, parent-child smart tickets, public-asset auto-tagging, Talos cluster support, mult... |
+| [3.6-release.md](3.6-release.md) | AccuKnox v3.6 introduces App-based Source Code Security for ASPM. Connect GitHub, GitLab, or Bitbucket once, then run SCA, Secrets, SAST, and IaC scans from... |
 | [accuknox-agents.md](accuknox-agents.md) | AccuKnox Agents are the agents that are part of the AccuKnox solution. These agents are responsible for enforcing the security policies and providing deep vi... |
 | [accuknox-arch.md](accuknox-arch.md) | A concise and detailed overview of AccuKnox's CNAPP architecture, components, and operational workflows. |
 | [accuknox-release-notes.md](accuknox-release-notes.md) | Browse AccuKnox release versions and changelogs. |

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -35,6 +35,7 @@ Task-oriented how-to guides: onboarding, configuration, and step-by-step procedu
 | [cluster-offboarding.md](cluster-offboarding.md) | Instructions for offboarding a cluster from AccuKnox SaaS, ensuring a clean and secure removal process. Follow this step-by-step guide. |
 | [cluster-onboarding-access-keys.md](cluster-onboarding-access-keys.md) | Guide to onboarding multiple clusters using access keys, with options to set expiration times and limit the number of onboarded clusters. |
 | [cluster-onboarding.md](cluster-onboarding.md) | Step-by-step guide on onboarding clusters to AccuKnox SaaS, including installing KubeArmor and AccuKnox agents for secure integration. |
+| [code-source-onboarding.md](code-source-onboarding.md) | Connect GitHub, GitLab, or Bitbucket to AccuKnox with a native app and run SCA, Secrets, SAST, and IaC scans from the platform, with no CI/CD pipeline setup.... |
 | [create-access-keys.md](create-access-keys.md) | Guide on creating secure access keys in AccuKnox SaaS to authenticate and authorize user access and manage permissions effectively. |
 | [cspm-prereq-aws.md](cspm-prereq-aws.md) | Onboarding pre-requisites for AWS accounts, including necessary permissions and configurations for secure integration. |
 | [cspm-prereq-azure.md](cspm-prereq-azure.md) | Pre-requisites and setup instructions for onboarding Azure cloud accounts to AccuKnox SaaS, ensuring automated security configuration. |

--- a/docs/integrations/jenkins-installation.md
+++ b/docs/integrations/jenkins-installation.md
@@ -14,7 +14,7 @@ This page walks through the one-time installation and global configuration of th
 - Network egress from the Jenkins agent to the AccuKnox control plane (or a mirrored scanner image for air-gapped agents).
 - Administrator access to Jenkins (`Manage Jenkins` / `Manage Plugins` / `System Configuration`).
 - The built artifact `accuknox-aspm.hpi` (or the published plugin).
-- Download `accuknox-aspm.hpi` from https://accuknox-aspm.s3.us-east-2.amazonaws.com/accuknox-aspm.hpi if you do not already have the file.
+- Download `accuknox-aspm.hpi` from https://accuknox-onprem-artifacts.s3.us-east-2.amazonaws.com/accuknox-aspm.hpi if you do not already have the file.
 
 ## 1. Deploy the `.hpi` to Jenkins
 


### PR DESCRIPTION
Updates the `accuknox-aspm.hpi` download link on the [Installing ASPM Jenkins Plugin](https://help.accuknox.com/integrations/jenkins-installation/) page to point to the on-prem artifacts bucket.

- Old: `https://accuknox-aspm.s3.us-east-2.amazonaws.com/accuknox-aspm.hpi`
- New: `https://accuknox-onprem-artifacts.s3.us-east-2.amazonaws.com/accuknox-aspm.hpi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)