### PR TITLE
Fix: IAM permissions list not loading on instant navigation + trim overview

### DIFF
--- a/docs/how-to/cspm-permissions-overview.md
+++ b/docs/how-to/cspm-permissions-overview.md
@@ -5,26 +5,14 @@ description: The read-only permissions AccuKnox CSPM requests for AWS, Azure, an
 
 # Least-Privilege Permissions Reference
 
-Before you onboard a cloud account, your team can review exactly what AccuKnox will read. This reference lists every permission the CSPM scanner requests for AWS, Azure, and GCP, with a plain-English reason for each.
+Every permission the AccuKnox CSPM scanner requests is **read-only**. It reads how your resources are configured to flag misconfigurations and build your asset inventory. It never changes anything, and never reads object contents, database rows, or secret payloads.
 
-**Every permission is read-only.** AccuKnox scans posture, it never changes your environment, and it never reads object contents, database rows, or secret payloads. It reads how resources are configured to flag misconfigurations and build your asset inventory.
+Pick your cloud to see every permission, grouped by service, with the reason for each on hover:
 
-| Cloud | Permissions | Scope | Full list |
-|---|---|---|---|
-| **AWS** | 403 read-only actions | IAM policy on a read-only user/role | [AWS Permissions Reference](cspm-permissions-aws.md) |
-| **Azure** | 209 permissions | AK Reader Aligned custom role | [Azure Permissions Reference](cspm-permissions-azure.md) |
-| **GCP** | 901 permissions across 41 services | Project-level custom role | [GCP Permissions Reference](cspm-permissions-gcp.md) |
+| Cloud | Permissions | Full list |
+|---|---|---|
+| **AWS** | 403 | [AWS Permissions Reference](cspm-permissions-aws.md) |
+| **Azure** | 209 | [Azure Permissions Reference](cspm-permissions-azure.md) |
+| **GCP** | 901 | [GCP Permissions Reference](cspm-permissions-gcp.md) |
 
-On each page, permissions are grouped by service. Hover a permission (or tap it on mobile) to see what it does, why AccuKnox needs it, and what you lose if it is not granted. Use the search box and service filter to jump straight to one.
-
-Denying a permission does not break the scan. It only creates a blind spot for that service: missing assets, or skipped findings for that area.
-
-## Legacy Azure services
-
-The Azure role intentionally keeps permissions for services Microsoft has retired for new customers (classic Redis, Spring Cloud, MySQL/PostgreSQL Single Server, classic Front Door). Many customers still run legacy instances, and dropping these would leave those workloads unaudited. See the [retired-services table](cspm-permissions-azure.md#support-for-retired-azure-services) on the Azure page.
-
-## Next steps
-
-- Review the full list for your cloud: [AWS](cspm-permissions-aws.md), [Azure](cspm-permissions-azure.md), or [GCP](cspm-permissions-gcp.md).
-- Set up the read-only role in the [onboarding prerequisites](cspm-prereq-aws.md).
-- Connect the account from the [CSPM onboarding guide](aws-onboarding.md).
+Denying a permission does not break the scan. It only creates a blind spot for that service: missing assets, or skipped findings.

--- a/docs/javascripts/iam-permissions.js
+++ b/docs/javascripts/iam-permissions.js
@@ -237,14 +237,38 @@
   }
 
   function init() {
-    document.querySelectorAll("div.iam-perms").forEach(buildOne);
+    document.querySelectorAll("div.iam-perms").forEach(function (c) {
+      // guard each build so one bad page can never kill the subscription
+      try { buildOne(c); } catch (e) { /* no-op */ }
+    });
   }
 
-  if (window.document$ && typeof window.document$.subscribe === "function") {
-    window.document$.subscribe(init);
-  } else if (document.readyState !== "loading") {
-    init();
-  } else {
-    document.addEventListener("DOMContentLoaded", init);
+  // Primary path: Material's instant navigation emits `document$` on the initial
+  // load AND on every in-app navigation. Subscribing once handles all of them.
+  // The catch is that `document$` may not exist yet at the moment this script
+  // runs (script/bundle order), which would otherwise leave us on a one-time
+  // DOMContentLoaded fallback that never fires on instant navigation. So we hook
+  // it as soon as it appears, and still render the current page in the meantime.
+  var subscribed = false;
+  function hookInstantNav() {
+    if (subscribed) return true;
+    if (window.document$ && typeof window.document$.subscribe === "function") {
+      subscribed = true;
+      window.document$.subscribe(init);
+      return true;
+    }
+    return false;
+  }
+
+  if (!hookInstantNav()) {
+    // render whatever is on screen right now...
+    if (document.readyState !== "loading") init();
+    else document.addEventListener("DOMContentLoaded", init);
+    // ...and keep trying to attach to instant navigation until Material is ready
+    var attempts = 0;
+    var timer = setInterval(function () {
+      attempts++;
+      if (hookInstantNav() || attempts > 50) clearInterval(timer);
+    }, 100);
   }
 })();


### PR DESCRIPTION
Follow-up to #594.

## Bug
On the IAM Permissions Reference pages, the interactive permission list did not render when arriving via the sidebar or an in-app link. It only appeared on a full page refresh.

**Cause:** the init code fell back to a one-time `DOMContentLoaded` run when Material's `document$` observable wasn't defined at the moment the script executed. `DOMContentLoaded` only fires on a full load, so instant navigation never re-ran the renderer.

**Fix (`docs/javascripts/iam-permissions.js`):** subscribe to `document$` resiliently, retrying until it's available instead of giving up on the DOMContentLoaded fallback. Each build is wrapped so a single error can't kill the subscription. Verified: instant-nav into a not-yet-visited permissions page now builds the component every time (AWS 403, Azure 209, GCP 901).

## Also
`docs/how-to/cspm-permissions-overview.md`: oversimplified to a short read-only intro + the pick-your-cloud table (~90 words).

🤖 Generated with [Claude Code](https://claude.com/claude-code)