### PR TITLE
Install mkdocs-glightbox in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,5 @@ jobs:
       - run: pip install mkdocs-redirects
       - run: pip install mkdocs-embed-external-markdown
       - run: pip install neoteroi-mkdocs
+      - run: pip install mkdocs-glightbox
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -24,6 +24,7 @@ jobs:
              pip install mkdocs-redirects
              pip install mkdocs-embed-external-markdown
              pip install neoteroi-mkdocs
+             pip install mkdocs-glightbox
              mkdocs build
 
      - name: Configure AWS Credentials


### PR DESCRIPTION
The v3.6 release enabled the `glightbox` plugin in `mkdocs.yml`, but neither workflow installs it. Both jobs abort with:

```
ERROR - Config value 'plugins': The "glightbox" plugin is not installed
```

Adds `pip install mkdocs-glightbox` to `ci.yml` (gh-deploy) and `workflow.yaml` (S3 build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)