### PR TITLE
Stop the lightbox from hijacking clicks on card icons

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1456,19 +1456,19 @@ hide:
     <h2 class="section-heading">Technical Support</h2>
     <div class="section5-card-container">
         <div class="section5-card">
-            <img src="introduction/cards/badge1.svg" alt="Tech Support Icon">
+            <img class="off-glb" src="introduction/cards/badge1.svg" alt="Tech Support Icon">
             <h3 class="section5-card-title">Raise Ticket</h3>
             <p>Contact our Support Team to quickly resolve any issues.</p>
             <a href="https://accu-knox.atlassian.net/servicedesk/customer/portal/1" target="_blank" class="section5-card-link">CONNECT WITH US &rarr;</a>
         </div>
         <div class="section5-card">
-            <img src="introduction/cards/badge2.svg" alt="Certification Icon">
+            <img class="off-glb" src="introduction/cards/badge2.svg" alt="Certification Icon">
             <h3 class="section5-card-title">AccuKnox Certifications</h3>
             <p>AccuKnox certifications ensure compliance with industry security standards.</p>
             <a href="https://www.accuknox.com/certifications" target="_blank" class="section5-card-link">GET CERTIFIED &rarr;</a>
         </div>
         <div class="section5-card">
-            <img src="introduction/cards/badge3.svg" alt="Downloads Icon">
+            <img class="off-glb" src="introduction/cards/badge3.svg" alt="Downloads Icon">
             <h3 class="section5-card-title">Resources</h3>
             <p>Download and make the most of AccuKnox guides and manuals.</p>
             <a href="/resources/accuknox-manual/" target="_blank" class="section5-card-link">DOWNLOAD NOW &rarr;</a>

--- a/hooks/glightbox_skip_linked_images.py
+++ b/hooks/glightbox_skip_linked_images.py
@@ -1,0 +1,61 @@
+"""Keep the lightbox off any image that already sits inside something clickable.
+
+mkdocs-glightbox decides whether to wrap an image by looking at its *direct*
+parent only. Every Neoteroi card puts its icon a few levels deeper than the
+card's own anchor:
+
+    <a href="/use-cases/cspm/">
+      <div><div class="nt-card-image tags"><img src="CSPM.svg"></div>...</div>
+    </a>
+
+so the plugin wraps the icon in a second anchor. Nested anchors are illegal
+HTML, the browser splits them apart, the card's link is destroyed, and clicking
+an icon opens the lightbox instead of navigating to the page.
+
+The same thing happens on the homepage, where the carousel cards and the module
+picker rows are plain divs carrying an onclick handler. Wrapping their images
+means the lightbox eats the click and the carousel never rotates.
+
+This patches the plugin's skip check to walk the whole ancestor chain and leave
+an image alone if anything above it is a link or has an onclick handler, no
+matter how deeply it is nested. Screenshots in page bodies are untouched and
+still open in the lightbox.
+
+It also skips images that declare a width or height of 64px or less. Those are
+inline glyphs sitting next to a line of text, and enlarging an 18px icon to fill
+the viewport is never what the reader wanted. Anything larger is treated as a
+screenshot. The `{: .off-glb }` opt-out still works for the rest.
+"""
+
+# Declared px size at or below which an image counts as an inline glyph.
+MAX_INLINE_ICON_PX = 64
+
+from mkdocs_glightbox.plugin import LightboxPlugin
+
+_original_should_skip_img = LightboxPlugin._should_skip_img
+
+
+def _inside_clickable(node):
+    parent = node.parent
+    while parent is not None:
+        if parent.tag == "a" or "onclick" in parent.attributes:
+            return True
+        parent = parent.parent
+    return False
+
+
+def _is_inline_icon(img):
+    for attr in ("width", "height"):
+        raw = (img.attributes.get(attr) or "").strip().rstrip("px").strip()
+        if raw.isdigit() and int(raw) <= MAX_INLINE_ICON_PX:
+            return True
+    return False
+
+
+def _should_skip_img(self, img, skip_classes, plugin_config, meta):
+    if _inside_clickable(img) or _is_inline_icon(img):
+        return True
+    return _original_should_skip_img(self, img, skip_classes, plugin_config, meta)
+
+
+LightboxPlugin._should_skip_img = _should_skip_img

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ plugins:
 # Customization
 hooks:
   - hooks/copy_md_source.py
+  - hooks/glightbox_skip_linked_images.py
 extra_css:
 - "assets/stylesheets/style.css"
 - "assets/stylesheets/extra.css"


### PR DESCRIPTION
## Problem

Clicking an icon on any card index page (`/use-cases/`, and the other `::cards::` pages) opened the image in a lightbox instead of navigating to the linked page. Card-based navigation was completely broken. Side effect of enabling `mkdocs-glightbox` in c3104241.

## Cause

`mkdocs-glightbox` decides whether to wrap an image by checking its **direct parent** for an `<a>` tag. Neoteroi puts the card icon three levels below the card's own anchor:

```html
<a href="/use-cases/cspm/">
  <div><div class="nt-card-image tags"><img src="CSPM.svg"></div>...</div>
</a>
```

So the plugin wrapped the icon in a second anchor. Nested anchors are illegal HTML, the browser splits them apart, the card's own link is destroyed, and the lightbox anchor is what receives the click.

The homepage hit the same class of bug with the screenshot carousel and the module picker rows, which are `<div>` elements carrying an `onclick` handler rather than links. The lightbox ate those clicks too, so the carousel would not rotate.

## Fix

New hook `hooks/glightbox_skip_linked_images.py` patches the plugin's skip check to walk the whole ancestor chain and skip an image when:

1. any ancestor is an `<a>` tag, or
2. any ancestor carries an `onclick` attribute, or
3. the image declares a width or height of 64px or less (inline glyphs next to a line of text)

The three support-section badge SVGs on the homepage declare no size, so they get an explicit `off-glb` class instead.

Screenshots in page bodies are untouched and still open in the lightbox. The existing `{: .off-glb }` opt-out keeps working.

## Verification

Built the full site and drove it in a browser.

| Check | Result |
|---|---|
| Click CSPM card icon on `/use-cases/` | navigates to `/use-cases/cspm/`, no lightbox |
| Card anchors on `/use-cases/` | 13 of 13 intact, 0 glightbox anchors |
| Homepage carousel side-card image click | rotates, no lightbox |
| Homepage module picker icon click | selects KSPM and shows its detail pane |
| `/use-cases/cnapp-security-overview/` | 22 screenshots still lightboxed, enlarged view opens |
| Nested `<a>` inside `<a>` sitewide | 0 |
| Total lightbox images sitewide | 2,135, all genuine screenshots |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
